### PR TITLE
All class visibility changed to internal

### DIFF
--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/Util.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/Util.kt
@@ -7,12 +7,13 @@ import java.util.*
 /**
  * @author Vilmos Nagy <vilmos.nagy@outlook.com>
  */
-internal data class IncludedArgs(val args: List<Any>)
+internal interface ValueClassUtil
+private data class IncludedArgs(private val args: List<Any>) : ValueClassUtil
 
-internal fun includedArgs(vararg args: Any) = IncludedArgs(args.toList())
+internal fun includedArgs(vararg args: Any): ValueClassUtil = IncludedArgs(args.toList())
 
-abstract class EqualsAndHashCode {
-    internal abstract val included : IncludedArgs
+internal abstract class EqualsAndHashCode {
+    internal abstract val included : ValueClassUtil
 
     override fun equals(other: Any?) = when {
         this === other -> true

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/FieldValueProvider.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/FieldValueProvider.kt
@@ -3,7 +3,7 @@ package com.github.vilmosnagy.elq.elqcore.cache
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class FieldValueProvider<T:Any>(private val fieldName: String): ValueProvider<T> {
+internal data class FieldValueProvider<T:Any>(private val fieldName: String): ValueProvider<T> {
 
     override fun getValue(cacheKey: T): Any? {
         val predicateClass = cacheKey.javaClass

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodParameterValueProvider.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodParameterValueProvider.kt
@@ -9,7 +9,7 @@ import java.lang.reflect.Method as JVMMethod
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class MethodParameterValueProvider<T>(internal val variableIndex: Int, internal val propertyCallChain: List<JVMMethod>): ValueProvider<Predicate<T>> {
+internal data class MethodParameterValueProvider<T>(internal val variableIndex: Int, internal val propertyCallChain: List<JVMMethod>): ValueProvider<Predicate<T>> {
 
     override fun getValue(cacheKey: Predicate<T>): Any? {
         val (proxiedInstance, interceptorChain) = getProxiedInstance<T>(propertyCallChain)

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodReturnValueProvider.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodReturnValueProvider.kt
@@ -5,10 +5,10 @@ import java.lang.reflect.Method as JVMMethod
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class MethodReturnValueProvider<T> (
-        private val targetMethod: JVMMethod,
-        private val objectInvokedOn: Any?,
-        private val parameters: List<ValueProvider<T>> = listOf()
+internal data class MethodReturnValueProvider<T> (
+        internal val targetMethod: JVMMethod,
+        internal val objectInvokedOn: Any?,
+        internal val parameters: List<ValueProvider<T>> = listOf()
 ) : ValueProvider<T> {
 
     override fun getValue(cacheKey: T): Any? {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/ValueProvider.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/cache/ValueProvider.kt
@@ -3,13 +3,13 @@ package com.github.vilmosnagy.elq.elqcore.cache
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-interface ValueProvider<T> {
+internal interface ValueProvider<T> {
 
     fun getValue(cacheKey: T): Any?
 
 }
 
-data class ConstantValueProvider<T>(private val value: Any?) : ValueProvider<T> {
+internal data class ConstantValueProvider<T>(private val value: Any?) : ValueProvider<T> {
     override fun getValue(cacheKey: T): Any? {
         return value
     }

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/Method.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/Method.kt
@@ -14,9 +14,9 @@ import java.lang.reflect.Method as JVMMethod
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class Method (
-        val jvmMethod: JVMMethod,
-        val returnStatement: Statement
+internal data class Method (
+        internal val jvmMethod: JVMMethod,
+        internal val returnStatement: Statement
 ): EvaluableStatement<Statement> {
     override val value: Statement
         get() = returnStatement

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/MethodCallChainProxies.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/MethodCallChainProxies.kt
@@ -2,7 +2,7 @@ package com.github.vilmosnagy.elq.elqcore.model
 
 import com.github.vilmosnagy.elq.elqcore.service.proxy.ArgumentFromPropertyCallChainInterceptor
 
-data class MethodCallChainProxies<T>(
-        val proxiedInstance: T,
-        val interceptors: ArgumentFromPropertyCallChainInterceptor
+internal data class MethodCallChainProxies<T>(
+        internal val proxiedInstance: T,
+        internal val interceptors: ArgumentFromPropertyCallChainInterceptor
 )

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionLeaf.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionLeaf.kt
@@ -5,10 +5,10 @@ import com.github.vilmosnagy.elq.elqcore.interfaces.ExpressionBuilder
 import com.github.vilmosnagy.elq.elqcore.interfaces.Predicate
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType
 
-data class ParsedFilterLQExpressionLeaf<ENTITY_TYPE> (
-        val fieldName: String,
-        val value: ValueProvider<Predicate<ENTITY_TYPE>>,
-        val compareType: CompareType
+internal data class ParsedFilterLQExpressionLeaf<ENTITY_TYPE> (
+        internal val fieldName: String,
+        internal val value: ValueProvider<Predicate<ENTITY_TYPE>>,
+        internal val compareType: CompareType
 ) {
     fun <EXPRESSION_TYPE> buildExpression(expressionBuilder: ExpressionBuilder<EXPRESSION_TYPE>, predicate: Predicate<ENTITY_TYPE>): EXPRESSION_TYPE {
         val evaluatedValue = value.getValue(predicate)

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCode.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCode.kt
@@ -1,14 +1,13 @@
 package com.github.vilmosnagy.elq.elqcore.model.opcodes
 
 import com.github.vilmosnagy.elq.elqcore.EqualsAndHashCode
-import com.github.vilmosnagy.elq.elqcore.IncludedArgs
 import com.github.vilmosnagy.elq.elqcore.includedArgs
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType
 
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-sealed class OpCode(val type: OpCodeType): EqualsAndHashCode() {
+internal sealed class OpCode(val type: OpCodeType) : EqualsAndHashCode() {
 
     override val included = includedArgs(type)
 
@@ -16,14 +15,15 @@ sealed class OpCode(val type: OpCodeType): EqualsAndHashCode() {
         val variableIndex: Int
     }
 
-    class iload_0(): OpCode(OpCodeType.iload_0), VariableToStackOperation {
+    class iload_0() : OpCode(OpCodeType.iload_0), VariableToStackOperation {
         override val variableIndex = 0
     }
 
-    class aload_0(): OpCode(OpCodeType.aload_0), VariableToStackOperation {
+    class aload_0() : OpCode(OpCodeType.aload_0), VariableToStackOperation {
         override val variableIndex = 0
     }
-    class aload_1(): OpCode(OpCodeType.aload_1), VariableToStackOperation {
+
+    class aload_1() : OpCode(OpCodeType.aload_1), VariableToStackOperation {
         override val variableIndex = 1
     }
 
@@ -34,56 +34,56 @@ sealed class OpCode(val type: OpCodeType): EqualsAndHashCode() {
             get() = indexByte1 * 256 + indexByte2
     }
 
-    interface InvokeFunctionOperation: TwoByteIndexOperation
+    interface InvokeFunctionOperation : TwoByteIndexOperation
 
-    class invokestatic(override val indexByte1: Int, override  val indexByte2: Int): OpCode(OpCodeType.invokestatic), InvokeFunctionOperation {
+    class invokestatic(override val indexByte1: Int, override val indexByte2: Int) : OpCode(OpCodeType.invokestatic), InvokeFunctionOperation {
         override val included = includedArgs(type, indexReference)
     }
 
-    class invokevirtual(override val indexByte1: Int, override  val indexByte2: Int): OpCode(OpCodeType.invokevirtual), InvokeFunctionOperation {
+    class invokevirtual(override val indexByte1: Int, override val indexByte2: Int) : OpCode(OpCodeType.invokevirtual), InvokeFunctionOperation {
         override val included = includedArgs(type, indexReference)
     }
 
-    class invokespecial(override val indexByte1: Int, override  val indexByte2: Int): OpCode(OpCodeType.invokespecial), InvokeFunctionOperation {
+    class invokespecial(override val indexByte1: Int, override val indexByte2: Int) : OpCode(OpCodeType.invokespecial), InvokeFunctionOperation {
         override val included = includedArgs(type, indexReference)
     }
 
     interface ConstToStackOperation
 
-    class ldc(val indexByte: Int): OpCode(OpCodeType.ldc), ConstToStackOperation
-    class dup: OpCode(OpCodeType.dup)
+    class ldc(val indexByte: Int) : OpCode(OpCodeType.ldc), ConstToStackOperation
+    class dup : OpCode(OpCodeType.dup)
 
-    interface IntToStackOperation: ConstToStackOperation {
+    interface IntToStackOperation : ConstToStackOperation {
         val value: Int
     }
 
-    class iconst_0(): OpCode(OpCodeType.iconst_0), IntToStackOperation {
+    class iconst_0() : OpCode(OpCodeType.iconst_0), IntToStackOperation {
         override val value = 0
     }
 
-    class iconst_1(): OpCode(OpCodeType.iconst_1), IntToStackOperation {
+    class iconst_1() : OpCode(OpCodeType.iconst_1), IntToStackOperation {
         override val value = 1
     }
 
-    class iconst_2(): OpCode(OpCodeType.iconst_2), IntToStackOperation {
+    class iconst_2() : OpCode(OpCodeType.iconst_2), IntToStackOperation {
         override val value = 2
     }
 
-    class iconst_3(): OpCode(OpCodeType.iconst_3), IntToStackOperation {
+    class iconst_3() : OpCode(OpCodeType.iconst_3), IntToStackOperation {
         override val value = 3
     }
 
-    class iconst_4(): OpCode(OpCodeType.iconst_4), IntToStackOperation {
+    class iconst_4() : OpCode(OpCodeType.iconst_4), IntToStackOperation {
         override val value = 4
     }
 
-    class iconst_5(): OpCode(OpCodeType.iconst_5), IntToStackOperation {
+    class iconst_5() : OpCode(OpCodeType.iconst_5), IntToStackOperation {
         override val value = 5
     }
 
     class bipush(override val value: Int) : OpCode(OpCodeType.bipush), IntToStackOperation
 
-    class sipush(byte1: Int, byte2: Int): OpCode(OpCodeType.sipush), IntToStackOperation {
+    class sipush(byte1: Int, byte2: Int) : OpCode(OpCodeType.sipush), IntToStackOperation {
         override val value = byte1 * 256 + byte2
     }
 
@@ -96,38 +96,42 @@ sealed class OpCode(val type: OpCodeType): EqualsAndHashCode() {
             get() = branchByte1 * 256 + branchByte2
     }
 
-    class if_icmpne(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.if_icmpne), BranchOperation {
+    class if_icmpne(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.if_icmpne), BranchOperation {
         override val compareType = CompareType.NOT_EQUALS
         override val included = includedArgs(type, branchIndex)
     }
-    class if_icmplt(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.if_icmplt), BranchOperation {
+
+    class if_icmplt(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.if_icmplt), BranchOperation {
         override val compareType = CompareType.LESS_THAN
         override val included = includedArgs(type, branchIndex)
     }
-    class if_icmpge(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.if_icmpge), BranchOperation {
+
+    class if_icmpge(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.if_icmpge), BranchOperation {
         override val compareType = CompareType.GREATER_THAN_OR_EQUALS
         override val included = includedArgs(type, branchIndex)
     }
-    class if_icmpgt(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.if_icmpgt), BranchOperation {
+
+    class if_icmpgt(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.if_icmpgt), BranchOperation {
         override val compareType = CompareType.GREATER_THAN
         override val included = includedArgs(type, branchIndex)
     }
-    class if_icmple(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.if_icmple), BranchOperation {
+
+    class if_icmple(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.if_icmple), BranchOperation {
         override val compareType = CompareType.LESS_THAN_OR_EQUALS
         override val included = includedArgs(type, branchIndex)
     }
 
-    class ifnonnull(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.ifnonnull), BranchOperation {
+    class ifnonnull(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.ifnonnull), BranchOperation {
         override val compareType = CompareType.NON_NULL
         override val included = includedArgs(type, branchIndex)
     }
 
     interface ReturnOperation<T>
-    interface IntReturnOperation: ReturnOperation<Int>
-    interface ObjectReturnOperation: ReturnOperation<Any>
+    interface IntReturnOperation : ReturnOperation<Int>
+    interface ObjectReturnOperation : ReturnOperation<Any>
 
-    class ireturn(): OpCode(OpCodeType.ireturn), IntReturnOperation
-    class areturn(): OpCode(OpCodeType.areturn), ObjectReturnOperation
+    class ireturn() : OpCode(OpCodeType.ireturn), IntReturnOperation
+    class areturn() : OpCode(OpCodeType.areturn), ObjectReturnOperation
 
     interface JumpOperation {
         val branchByte1: Int
@@ -135,8 +139,9 @@ sealed class OpCode(val type: OpCodeType): EqualsAndHashCode() {
         val branchIndex: Int
             get() = branchByte1 * 256 + branchByte2
     }
-    class goto(override val branchByte1: Int, override val branchByte2: Int): OpCode(OpCodeType.goto), JumpOperation
 
-    class getfield(override val indexByte1: Int, override val indexByte2: Int): OpCode(OpCodeType.getfield), TwoByteIndexOperation
+    class goto(override val branchByte1: Int, override val branchByte2: Int) : OpCode(OpCodeType.goto), JumpOperation
+
+    class getfield(override val indexByte1: Int, override val indexByte2: Int) : OpCode(OpCodeType.getfield), TwoByteIndexOperation
 
 }

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCodeType.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCodeType.kt
@@ -2,7 +2,7 @@ package com.github.vilmosnagy.elq.elqcore.model.opcodes
 
 import org.apache.bcel.classfile.JavaClass
 
-internal enum class OpCodeType(val opCode: Int, val otherByteCount: Int = 0) {
+internal enum class OpCodeType(internal val opCode: Int, internal val otherByteCount: Int = 0) {
     //<editor-fold desc="iload_0">
     iload_0(0x1A) {
         override fun createNew(followingBytes: List<Int>, bcelClass: JavaClass): OpCode {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/GetFieldStatement.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/GetFieldStatement.kt
@@ -3,7 +3,7 @@ package com.github.vilmosnagy.elq.elqcore.model.statements
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-class GetFieldStatement(
-        val javaClass: Class<*>,
-        val fieldName: String
+internal class GetFieldStatement(
+        internal val javaClass: Class<*>,
+        internal val fieldName: String
 ): Statement

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/MethodCallStatement.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/MethodCallStatement.kt
@@ -7,13 +7,13 @@ import java.lang.reflect.Method as JVMMethod
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class MethodCallStatement<out T> (
-        val targetClass: Class<*>,
-        val targetMethod: java.lang.reflect.Method,
-        val parameters: List<Statement> = listOf(),
-        val returnType: Class<out T>,
+internal data class MethodCallStatement<out T>(
+        internal val targetClass: Class<*>,
+        internal val targetMethod: java.lang.reflect.Method,
+        internal val parameters: List<Statement> = listOf(),
+        internal val returnType: Class<out T>,
         private val evaluatedStatement: Statement? = null
-): Statement.EvaluableStatement<Method>, Statement.LazyEvaluatedStatement<Method> {
+) : Statement.EvaluableStatement<Method>, Statement.LazyEvaluatedStatement<Method> {
 
     override val value: Method by lazy {
         if (evaluatedStatement != null) {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/Statement.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/Statement.kt
@@ -5,7 +5,7 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-interface Statement {
+internal interface Statement {
 
     fun evaluate(): Any? {
         return this;

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/BranchedStatement.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/BranchedStatement.kt
@@ -5,8 +5,8 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class BranchedStatement(
-        val compareStatement: CompareStatement,
-        val branch01: Statement,
-        val branch02: Statement
+internal data class BranchedStatement(
+        internal val compareStatement: CompareStatement,
+        internal val branch01: Statement,
+        internal val branch02: Statement
 ): Statement

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/CompareStatement.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/CompareStatement.kt
@@ -5,7 +5,7 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-data class CompareStatement(
+internal data class CompareStatement(
         val v1: Statement,
         val v2: Statement,
         val compareType: CompareType

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/CompareType.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/branch/CompareType.kt
@@ -1,6 +1,6 @@
 package com.github.vilmosnagy.elq.elqcore.model.statements.branch
 
-enum class CompareType {
+internal enum class CompareType {
     NOT_EQUALS { override fun negate() = EQUALS },
     EQUALS { override fun negate() = NOT_EQUALS },
 
@@ -11,5 +11,5 @@ enum class CompareType {
 
     NON_NULL { override fun negate() = TODO() };
 
-    abstract fun negate(): CompareType
+    internal abstract fun negate(): CompareType
 }

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/kotlin/SpecialReturnStatements.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/kotlin/SpecialReturnStatements.kt
@@ -5,4 +5,4 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-object ThrowUninitializedPropertyAccessException: Statement
+internal object ThrowUninitializedPropertyAccessException: Statement

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionService.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionService.kt
@@ -1,8 +1,6 @@
 package com.github.vilmosnagy.elq.elqcore.service
 
-import com.avaje.ebean.Expression
 import com.github.vilmosnagy.elq.elqcore.cache.*
-import com.github.vilmosnagy.elq.elqcore.interfaces.ExpressionBuilder
 import com.github.vilmosnagy.elq.elqcore.interfaces.Predicate
 import com.github.vilmosnagy.elq.elqcore.isStatic
 import com.github.vilmosnagy.elq.elqcore.model.Method
@@ -12,11 +10,9 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.MethodCallStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.BranchedStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType
-import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType.*
 import com.github.vilmosnagy.elq.elqcore.model.statements.kotlin.ThrowUninitializedPropertyAccessException
 import java.io.Serializable
 import java.lang.invoke.SerializedLambda
-import java.lang.reflect.Modifier
 import javax.inject.Inject
 import javax.inject.Singleton
 import java.lang.reflect.Method as JVMMethod
@@ -25,7 +21,7 @@ import java.lang.reflect.Method as JVMMethod
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-class LambdaToExpressionService
+internal class LambdaToExpressionService
 @Inject constructor(
         private val methodParser: MethodParser
 ) {
@@ -79,11 +75,11 @@ class LambdaToExpressionService
     }
 
     private fun getCompareTypeAndNegateIfNecessary(returnStatement: BranchedStatement): CompareType {
-      return if (returnStatement.branch01.evaluate() == true) {
-          returnStatement.compareStatement.compareType.negate()
-      } else {
-          returnStatement.compareStatement.compareType
-      }
+        return if (returnStatement.branch01.evaluate() == true) {
+            returnStatement.compareStatement.compareType.negate()
+        } else {
+            returnStatement.compareStatement.compareType
+        }
     }
 
     private fun simpleTrueFalseBranch(returnStatement: BranchedStatement): Boolean {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParser.kt
@@ -18,8 +18,8 @@ import java.lang.reflect.Method as JVMMethod
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-open class MethodParser @Inject constructor(
-        val generalOpCodeParser: GeneralOpCodeParser
+internal open class MethodParser @Inject constructor(
+        private val generalOpCodeParser: GeneralOpCodeParser
 ) {
 
     open fun parseMethod(classToParse: Class<*>, declaredMethod: JVMMethod): Method {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParser.kt
@@ -17,7 +17,7 @@ import java.lang.reflect.Method as JVMMethod
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-open class GeneralOpCodeParser @Inject constructor(
+internal open class GeneralOpCodeParser @Inject constructor(
         private val invokeOpCodeParser: InvokeOpCodeParser
 ) {
 

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParser.kt
@@ -16,8 +16,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-open class InvokeOpCodeParser @Inject constructor(
-        val methodCallHandlerService: MethodCallHandlerService
+internal open class InvokeOpCodeParser @Inject constructor(
+        private val methodCallHandlerService: MethodCallHandlerService
 ) {
 
     open fun parseInvokeOpCode(opCode: OpCode.InvokeFunctionOperation,

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/JavaBooleanMethodCallHandlers.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/JavaBooleanMethodCallHandlers.kt
@@ -11,7 +11,7 @@ import java.lang.Boolean
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-class JavaBooleanValueOfMethodCallHandler: MethodCallHandler {
+internal class JavaBooleanValueOfMethodCallHandler: MethodCallHandler {
 
     companion object {
         val METHOD_CALL = MethodCall(MethodCallType.INVOKE_STATIC, Boolean::class.java, Boolean::class.java.getDeclaredMethod("valueOf", Boolean.TYPE))

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/JavaObjectMethodCallHandlers.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/JavaObjectMethodCallHandlers.kt
@@ -11,7 +11,7 @@ import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallH
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-class JavaObjectEqualsMethodCallHandler : MethodCallHandler {
+internal class JavaObjectEqualsMethodCallHandler : MethodCallHandler {
 
     override fun getMethodCall(): MethodCall? {
         return null;

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/KotlinInternalMethodCallHandlers.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/KotlinInternalMethodCallHandlers.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.internal.Intrinsics
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-class KotlinInternalEqualsMethodCallHandler : MethodCallHandler {
+internal class KotlinInternalEqualsMethodCallHandler : MethodCallHandler {
 
     companion object {
         val METHOD_CALL = MethodCall(
@@ -38,7 +38,7 @@ class KotlinInternalEqualsMethodCallHandler : MethodCallHandler {
 
 }
 
-class KotlinInternalThrowUninitializedPropertyAccessExceptionMethodCallHandler : MethodCallHandler {
+internal class KotlinInternalThrowUninitializedPropertyAccessExceptionMethodCallHandler : MethodCallHandler {
 
     companion object {
         val METHOD_CALL = MethodCall(

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandler.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandler.kt
@@ -8,7 +8,7 @@ import java.lang.reflect.Method
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-interface MethodCallHandler {
+internal interface MethodCallHandler {
 
     enum class MethodCallType {
         INVOKE_STATIC, INVOKE_DYNAMIC, INVOKE_SPECIAL, INVOKE_VIRTUAL

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandlerService.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandlerService.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-open class MethodCallHandlerService @Inject constructor() {
+internal open class MethodCallHandlerService @Inject constructor() {
 
     private val specialMethodCallHandlers: MutableList<MethodCallHandler> = mutableListOf(
             JavaBooleanValueOfMethodCallHandler(), KotlinInternalEqualsMethodCallHandler(), JavaObjectEqualsMethodCallHandler(), KotlinInternalThrowUninitializedPropertyAccessExceptionMethodCallHandler()

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/proxy/ArgumentFromPropertyCallChainInterceptor.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/proxy/ArgumentFromPropertyCallChainInterceptor.kt
@@ -5,11 +5,11 @@ import net.sf.cglib.proxy.MethodInterceptor
 import net.sf.cglib.proxy.MethodProxy
 import java.lang.reflect.Method
 
-class ArgumentFromPropertyCallChainInterceptor(val propertyCallChain: List<Method>) : MethodInterceptor {
+internal class ArgumentFromPropertyCallChainInterceptor(private val propertyCallChain: List<Method>) : MethodInterceptor {
 
-    val original: Any by lazy { propertyCallChain[0].declaringClass.newInstance() }
-    var nextInterceptor: ArgumentFromPropertyCallChainInterceptor? = null
-    var capturedArguments: Array<out Any?>? = null
+    private val original: Any by lazy { propertyCallChain[0].declaringClass.newInstance() }
+    private var nextInterceptor: ArgumentFromPropertyCallChainInterceptor? = null
+    private var capturedArguments: Array<out Any?>? = null
 
     override fun intercept(proxy: Any?, method: Method?, args: Array<out Any?>?, mproxy: MethodProxy?): Any? {
         return if (propertyCallChain.size > 1) {
@@ -35,8 +35,8 @@ class ArgumentFromPropertyCallChainInterceptor(val propertyCallChain: List<Metho
         return method?.invoke(original, *varargs)
     }
 
-    private fun <T> getDefaultValue(clazz: Class<T>): T {
-        return java.lang.reflect.Array.get(java.lang.reflect.Array.newInstance(clazz, 1), 0) as T
+    private fun <T> getDefaultValue(clazz: Class<T>): Any? {
+        return java.lang.reflect.Array.get(java.lang.reflect.Array.newInstance(clazz, 1), 0)
     }
 
     fun getLastCapturedArguments(): Array<out Any?>? {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/stream/ElqStreamImpl.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/stream/ElqStreamImpl.kt
@@ -9,7 +9,7 @@ import java.util.stream.Collector
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-public data class ElqStreamImpl<T>  private constructor(
+internal data class ElqStreamImpl<T>  private constructor(
         private val clazz: Class<T>,
         private val query: Query<T>
 ) : ElqStream<T> {
@@ -47,6 +47,13 @@ public data class ElqStreamImpl<T>  private constructor(
     }
 }
 
+/**
+ * Creates a new Ebean Lambda Query Stream.
+ *
+ * @param T the type of the entity in this stream
+ * @param clazz the non-null [Class] representing the entity in this stream
+ * @return the new Ebean Lambda Query Stream
+ */
 public fun <T> createElqStream(clazz: Class<T>): ElqStream<T> {
     return ElqStreamImpl(clazz)
 }

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParserTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParserTest.kt
@@ -31,10 +31,10 @@ import java.lang.reflect.Method as JVMMethod
 class GeneralOpCodeParserTest : FeatureSpec() {
 
     @Mock
-    lateinit var invokeOpCodeParser: InvokeOpCodeParser
+    private lateinit var invokeOpCodeParser: InvokeOpCodeParser
 
     @InjectMocks
-    lateinit var testObj: GeneralOpCodeParser
+    private lateinit var testObj: GeneralOpCodeParser
 
     init {
         MockitoAnnotations.initMocks(this)

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParserTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParserTest.kt
@@ -28,10 +28,10 @@ import java.util.*
 class InvokeOpCodeParserTest : FeatureSpec() {
 
     @Mock
-    lateinit var methodCallHandlerService: MethodCallHandlerService
+    private lateinit var methodCallHandlerService: MethodCallHandlerService
 
     @InjectMocks
-    lateinit var testObj: InvokeOpCodeParser
+    private lateinit var testObj: InvokeOpCodeParser
 
     init {
         MockitoAnnotations.initMocks(this)


### PR DESCRIPTION
All class' (except the `ExpressionBuilder` interface's and the `createElqStream` method's) visibility changed to internal. Most of the variables' visibility changed to the minimal scope also.

It's possible, that in the future you'll be able to add other `ExpressionBuilder`s so that'll be `public` in the future.

Closes #5 