### PR TITLE
discarded all `open` modifiers in the production code.

### DIFF
--- a/elq-core/build.gradle
+++ b/elq-core/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     testCompile 'io.kotlintest:kotlintest:1.3.5'
     testCompile "com.nhaarman:mockito-kotlin:0.11.0"
+    testCompile 'de.jodamob.kotlin:kotlin-runner-junit4:0.3.1'
 
     compileOnly "javax.persistence:persistence-api:1.0.2"
     testCompile "javax.persistence:persistence-api:1.0.2"

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/EbeanExpressionBuilder.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/EbeanExpressionBuilder.kt
@@ -7,7 +7,7 @@ import com.github.vilmosnagy.elq.elqcore.interfaces.ExpressionBuilder
 /**
  * @author Vilmos Nagy <vilmos.nagy@outlook.com>
  */
-internal open class EbeanExpressionBuilder : ExpressionBuilder<Expression> {
+internal class EbeanExpressionBuilder : ExpressionBuilder<Expression> {
     override fun and(lhs: Expression, rhs: Expression): Expression = Expr.and(lhs, rhs)
     override fun or(lhs: Expression, rhs: Expression): Expression = Expr.or(lhs, rhs)
     override fun greaterThan(fieldName: String, value: Any?): Expression = Expr.gt(fieldName, value)

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParser.kt
@@ -18,11 +18,11 @@ import java.lang.reflect.Method as JVMMethod
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-internal open class MethodParser @Inject constructor(
+internal class MethodParser @Inject constructor(
         private val generalOpCodeParser: GeneralOpCodeParser
 ) {
 
-    open fun parseMethod(classToParse: Class<*>, declaredMethod: JVMMethod): Method {
+    fun parseMethod(classToParse: Class<*>, declaredMethod: JVMMethod): Method {
         val bcelClass = Repository.lookupClass(classToParse.name)
         val bcelMethod = bcelClass.getMethod(declaredMethod)
         val opCodes = codeToOpCodeList(bcelClass, bcelMethod.code)
@@ -34,7 +34,7 @@ internal open class MethodParser @Inject constructor(
         val retList = mutableListOf<OpCode>()
         var i = 0
         val methodCode = method.code.map { if (it < 0) (256 + it.toInt()) else it.toInt() }
-        while(i < methodCode.size) {
+        while (i < methodCode.size) {
             val opcodeType = OpCodeType.values().firstOrNull { it.opCode == methodCode[i] }
 
             @Suppress("FoldInitializerAndIfToElvis")
@@ -50,7 +50,7 @@ internal open class MethodParser @Inject constructor(
     }
 
     // TODO test
-    open fun unravelMethodCallChain(evaluableStatement: Statement.EvaluableStatement<*>): Statement.EvaluableStatement<*> {
+    fun unravelMethodCallChain(evaluableStatement: Statement.EvaluableStatement<*>): Statement.EvaluableStatement<*> {
         var subMethodCallBody = evaluableStatement
         while (subMethodCallBody.value is MethodCallStatement<*>) {
             subMethodCallBody = (subMethodCallBody.value as MethodCallStatement<*>).value.returnStatement as Statement.EvaluableStatement<*>

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParser.kt
@@ -17,7 +17,7 @@ import java.lang.reflect.Method as JVMMethod
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-internal open class GeneralOpCodeParser @Inject constructor(
+internal class GeneralOpCodeParser @Inject constructor(
         private val invokeOpCodeParser: InvokeOpCodeParser
 ) {
 
@@ -29,7 +29,7 @@ internal open class GeneralOpCodeParser @Inject constructor(
         }
     }
 
-    open fun parseExpressionList(opCodeList: List<OpCode>, bcelClass: JavaClass, jvmMethod: java.lang.reflect.Method, stack: Deque<Statement> = ArrayDeque()): Statement {
+    fun parseExpressionList(opCodeList: List<OpCode>, bcelClass: JavaClass, jvmMethod: java.lang.reflect.Method, stack: Deque<Statement> = ArrayDeque()): Statement {
         val opCodes = getIndexedOpCodeList(opCodeList)
         var nextIndex = 0
 

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParser.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParser.kt
@@ -5,7 +5,6 @@ package com.github.vilmosnagy.elq.elqcore.service.opcode
 import com.github.vilmosnagy.elq.elqcore.model.opcodes.OpCode
 import com.github.vilmosnagy.elq.elqcore.model.statements.MethodCallStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
-import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler.MethodCall
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler.MethodCallType
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandlerService
@@ -16,13 +15,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal open class InvokeOpCodeParser @Inject constructor(
+internal class InvokeOpCodeParser @Inject constructor(
         private val methodCallHandlerService: MethodCallHandlerService
 ) {
 
-    open fun parseInvokeOpCode(opCode: OpCode.InvokeFunctionOperation,
-                               targetClassName: String, methodName: String, methodSignature: String,
-                               parameters: List<Statement>): MethodCallStatement<*> {
+    fun parseInvokeOpCode(opCode: OpCode.InvokeFunctionOperation,
+                          targetClassName: String, methodName: String, methodSignature: String,
+                          parameters: List<Statement>): MethodCallStatement<*> {
         val methodParameterList = getMethodParameters(methodSignature)
         val targetClass = Class.forName(targetClassName)
         val targetMethod = targetClass.getDeclaredMethod(methodName, *methodParameterList.toTypedArray())
@@ -46,7 +45,7 @@ internal open class InvokeOpCodeParser @Inject constructor(
         return MethodCall(methodCallType, targetClass, targetMethod)
     }
 
-    open fun getParameterCount(opCode: OpCode.InvokeFunctionOperation, methodSignature: String): Int {
+    fun getParameterCount(opCode: OpCode.InvokeFunctionOperation, methodSignature: String): Int {
         val methodParameterList = getMethodParameters(methodSignature)
 
         return if (opCode is OpCode.invokevirtual) {

--- a/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandlerService.kt
+++ b/elq-core/src/main/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/callhandlers/MethodCallHandlerService.kt
@@ -10,17 +10,17 @@ import javax.inject.Singleton
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
 @Singleton
-internal open class MethodCallHandlerService @Inject constructor() {
+internal class MethodCallHandlerService @Inject constructor() {
 
     private val specialMethodCallHandlers: MutableList<MethodCallHandler> = mutableListOf(
             JavaBooleanValueOfMethodCallHandler(), KotlinInternalEqualsMethodCallHandler(), JavaObjectEqualsMethodCallHandler(), KotlinInternalThrowUninitializedPropertyAccessExceptionMethodCallHandler()
     )
 
-    open fun requiresSpecialHandle(methodCall: MethodCall): Boolean {
+    fun requiresSpecialHandle(methodCall: MethodCall): Boolean {
         return specialMethodCallHandlers.any { it.handles(methodCall) }
     }
 
-    open fun handleSpecialMethodCall(methodCall: MethodCall, parameters: List<Statement>): MethodCallStatement<*> {
+    fun handleSpecialMethodCall(methodCall: MethodCall, parameters: List<Statement>): MethodCallStatement<*> {
         val handlers = specialMethodCallHandlers.filter { it.handles(methodCall) }.toList()
         if (handlers.size != 1) {
             throw IllegalStateException()

--- a/elq-core/src/test/java/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionServiceJavaTest.java
+++ b/elq-core/src/test/java/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionServiceJavaTest.java
@@ -11,11 +11,14 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.branch.BranchedStateme
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareStatement;
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType;
 import com.github.vilmosnagy.elq.elqcore.test.model.TestEntity;
+import de.jodamob.kotlin.testrunner.KotlinTestRunner;
+import de.jodamob.kotlin.testrunner.OpenedPackages;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
@@ -28,7 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(KotlinTestRunner.class)
+@OpenedPackages("com.github.vilmosnagy.elq.elqcore")
 public class LambdaToExpressionServiceJavaTest {
 
     @Mock
@@ -39,6 +43,11 @@ public class LambdaToExpressionServiceJavaTest {
 
     @InjectMocks
     private LambdaToExpressionService testObj;
+
+    @Before
+    public final void before() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void should_transform_parsed_method_to_fieldName_value_pair_when_expression_is_field_equals_constant() throws NoSuchMethodException {

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/KotlinTestRunner.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/KotlinTestRunner.kt
@@ -1,0 +1,24 @@
+package com.github.vilmosnagy.elq.elqcore
+
+import de.jodamob.kotlin.testrunner.configureClassOpeningClassLoader
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.TestBase
+import org.junit.runner.Description
+import org.junit.runner.Runner
+import org.junit.runner.notification.RunNotifier
+
+/**
+ * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
+ */
+class KotlinTestRunner(klass: Class<TestBase>) : Runner() {
+    val runner: KTestJUnitRunner = KTestJUnitRunner(configureClassOpeningClassLoader(klass) as Class<TestBase>)
+
+    override fun run(notifier: RunNotifier?) {
+        runner.run(notifier)
+    }
+
+    override fun getDescription(): Description? {
+        return runner.description
+    }
+
+}

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodParameterValueProviderTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodParameterValueProviderTest.kt
@@ -1,14 +1,15 @@
 package com.github.vilmosnagy.elq.elqcore.cache
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.interfaces.Predicate
-import com.github.vilmosnagy.elq.elqcore.service.proxy.ArgumentFromPropertyCallChainInterceptor
 import io.kotlintest.specs.FeatureSpec
-import org.mockito.InjectMocks
+import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
+@RunWith(KotlinTestRunner::class)
 class MethodParameterValueProviderTest : FeatureSpec() {
 
     open class Bar {

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodReturnValueProviderTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/cache/MethodReturnValueProviderTest.kt
@@ -1,19 +1,18 @@
 package com.github.vilmosnagy.elq.elqcore.cache
 
-import com.github.vilmosnagy.elq.elqcore.test.model.TestEntity
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import io.kotlintest.specs.FeatureSpec
-import org.junit.Assert.*
+import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 import java.util.*
 
 /**
  * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
  */
+@RunWith(KotlinTestRunner::class)
 class MethodReturnValueProviderTest : FeatureSpec() {
-
-    private open class TestPredicate
 
     init {
         MockitoAnnotations.initMocks(this)
@@ -34,3 +33,5 @@ class MethodReturnValueProviderTest : FeatureSpec() {
         }
     }
 }
+
+internal class TestPredicate

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionLeafTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionLeafTest.kt
@@ -1,21 +1,22 @@
 package com.github.vilmosnagy.elq.elqcore.model.lqexpressions.filter
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.cache.ValueProvider
 import com.github.vilmosnagy.elq.elqcore.interfaces.ExpressionBuilder
 import com.github.vilmosnagy.elq.elqcore.interfaces.Predicate
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType
-import com.github.vilmosnagy.elq.elqcore.model.statements.branch.LogicalType
 import com.github.vilmosnagy.elq.elqcore.test.model.TestEntity
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import io.kotlintest.specs.FeatureSpec
-import org.junit.Assert.*
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
 /**
  * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
  */
+@RunWith(KotlinTestRunner::class)
 class ParsedFilterLQExpressionLeafTest : FeatureSpec() {
 
     @Mock

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionNodeTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/lqexpressions/filter/ParsedFilterLQExpressionNodeTest.kt
@@ -1,5 +1,6 @@
 package com.github.vilmosnagy.elq.elqcore.model.lqexpressions.filter
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.interfaces.ExpressionBuilder
 import com.github.vilmosnagy.elq.elqcore.interfaces.Predicate
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.LogicalType
@@ -7,13 +8,14 @@ import com.github.vilmosnagy.elq.elqcore.test.model.TestEntity
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import io.kotlintest.specs.FeatureSpec
-import org.junit.Assert.*
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
 /**
  * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
  */
+@RunWith(KotlinTestRunner::class)
 class ParsedFilterLQExpressionNodeTest : FeatureSpec() {
 
     @Mock

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCodeTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/opcodes/OpCodeTest.kt
@@ -1,11 +1,14 @@
 package com.github.vilmosnagy.elq.elqcore.model.opcodes
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.nhaarman.mockito_kotlin.mock
 import io.kotlintest.specs.FeatureSpec
+import org.junit.runner.RunWith
 
 /**
  * @author Vilmos Nagy  <vilmos.nagy></vilmos.nagy>@outlook.com>
  */
+@RunWith(KotlinTestRunner::class)
 class OpCodeTest : FeatureSpec() {
 
     init {

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/MethodCallStatementTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/model/statements/MethodCallStatementTest.kt
@@ -1,22 +1,25 @@
 package com.github.vilmosnagy.elq.elqcore.model.statements
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.dagger.AppCtx
 import com.github.vilmosnagy.elq.elqcore.model.Method
 import com.github.vilmosnagy.elq.elqcore.service.MethodParser
-import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import de.jodamob.kotlin.testrunner.OpenedPackages
 import io.kotlintest.specs.FeatureSpec
-import org.junit.Assert.*
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
-class MethodCallStatementTest: FeatureSpec() {
+@RunWith(KotlinTestRunner::class)
+@OpenedPackages("com.github.vilmosnagy.elq.elqcore")
+class MethodCallStatementTest : FeatureSpec() {
 
-    open class A {
-        open fun foo(): Boolean = true
+    private class A {
+        fun foo(): Boolean = true
     }
 
     @Mock
@@ -25,7 +28,7 @@ class MethodCallStatementTest: FeatureSpec() {
     @Mock
     private lateinit var methodParser: MethodParser
 
-    init{
+    init {
         MockitoAnnotations.initMocks(this)
         AppCtx.mockedAppCtx = appCtx
 

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionServiceTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/LambdaToExpressionServiceTest.kt
@@ -2,6 +2,7 @@
 
 package com.github.vilmosnagy.elq.elqcore.service
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.cache.ConstantValueProvider
 import com.github.vilmosnagy.elq.elqcore.cache.MethodParameterValueProvider
 import com.github.vilmosnagy.elq.elqcore.cache.MethodReturnValueProvider
@@ -20,7 +21,9 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.branch.LogicalType
 import com.github.vilmosnagy.elq.elqcore.test.model.TestEntity
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import de.jodamob.kotlin.testrunner.OpenedPackages
 import io.kotlintest.specs.FeatureSpec
+import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -29,6 +32,8 @@ import java.util.*
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
+@RunWith(KotlinTestRunner::class)
+@OpenedPackages("com.github.vilmosnagy.elq.elqcore")
 class LambdaToExpressionServiceTest : FeatureSpec() {
 
     @Mock

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParserTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/MethodParserTest.kt
@@ -1,5 +1,6 @@
 package com.github.vilmosnagy.elq.elqcore.service
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.model.Method
 import com.github.vilmosnagy.elq.elqcore.model.opcodes.OpCode
 import com.github.vilmosnagy.elq.elqcore.model.opcodes.OpCodeType
@@ -7,19 +8,20 @@ import com.github.vilmosnagy.elq.elqcore.model.statements.MethodCallStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 import com.github.vilmosnagy.elq.elqcore.service.opcode.GeneralOpCodeParser
 import com.nhaarman.mockito_kotlin.*
+import de.jodamob.kotlin.testrunner.OpenedPackages
 import io.kotlintest.specs.FeatureSpec
 import org.apache.bcel.Repository
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import org.mockito.runners.MockitoJUnitRunner
 
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
+@RunWith(KotlinTestRunner::class)
+@OpenedPackages("com.github.vilmosnagy.elq.elqcore")
 class MethodParserTest : FeatureSpec() {
 
     @Mock
@@ -71,9 +73,9 @@ class MethodParserTest : FeatureSpec() {
     }
 }
 
-inline fun <reified T : Any> eqf(value: T): T = Mockito.eq(value) ?: value
+internal inline fun <reified T : Any> eqf(value: T): T = Mockito.eq(value) ?: value
 
-class ClassWithSimpleGetter {
+open class ClassWithSimpleGetter {
     fun getVariable(): Any? {
         return 1
     }

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParserTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/GeneralOpCodeParserTest.kt
@@ -2,25 +2,31 @@
 
 package com.github.vilmosnagy.elq.elqcore.service.opcode
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.model.FunctionIntegerIsFive
 import com.github.vilmosnagy.elq.elqcore.model.opcodes.OpCode.*
 import com.github.vilmosnagy.elq.elqcore.model.statements.MethodCallStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement.ReturnStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.BranchedStatement
-import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType.NOT_EQUALS
 import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareStatement
-import com.nhaarman.mockito_kotlin.*
+import com.github.vilmosnagy.elq.elqcore.model.statements.branch.CompareType.NOT_EQUALS
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import de.jodamob.kotlin.testrunner.OpenedPackages
 import io.kotlintest.specs.FeatureSpec
 import org.apache.bcel.Const
 import org.apache.bcel.Repository
 import org.apache.bcel.classfile.ConstantString
 import org.apache.bcel.classfile.ConstantUtf8
 import org.apache.bcel.classfile.JavaClass
+import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
+import java.lang.Integer
 import org.apache.bcel.classfile.Method as BCELMethod
 import java.lang.Boolean as JavaBoolean
 import java.lang.reflect.Method as JVMMethod
@@ -28,6 +34,8 @@ import java.lang.reflect.Method as JVMMethod
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
+@RunWith(KotlinTestRunner::class)
+@OpenedPackages("com.github.vilmosnagy.elq.elqcore")
 class GeneralOpCodeParserTest : FeatureSpec() {
 
     @Mock
@@ -143,7 +151,7 @@ class GeneralOpCodeParserTest : FeatureSpec() {
 }
 
 
-class FakeTestClass {
+internal class FakeTestClass {
     fun returnBoolean(): Boolean = true
     fun returnInt(): Int = 0
 }

--- a/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParserTest.kt
+++ b/elq-core/src/test/kotlin/com/github/vilmosnagy/elq/elqcore/service/opcode/InvokeOpCodeParserTest.kt
@@ -2,15 +2,16 @@
 
 package com.github.vilmosnagy.elq.elqcore.service.opcode
 
+import com.github.vilmosnagy.elq.elqcore.KotlinTestRunner
 import com.github.vilmosnagy.elq.elqcore.model.opcodes.OpCode
 import com.github.vilmosnagy.elq.elqcore.model.statements.MethodCallStatement
 import com.github.vilmosnagy.elq.elqcore.model.statements.Statement
-import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler.MethodCall
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandler.MethodCallType.INVOKE_STATIC
 import com.github.vilmosnagy.elq.elqcore.service.opcode.callhandlers.MethodCallHandlerService
 import com.nhaarman.mockito_kotlin.whenever
 import io.kotlintest.specs.FeatureSpec
+import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -25,6 +26,7 @@ import java.util.*
 /**
  * @author Vilmos Nagy {@literal <vilmos.nagy@outlook.com>}
  */
+@RunWith(KotlinTestRunner::class)
 class InvokeOpCodeParserTest : FeatureSpec() {
 
     @Mock


### PR DESCRIPTION
Discarded all `open` modifiers in the production code. Some classes in the test-code still `open`, to work correctly with the current implementation.

Closes #6 